### PR TITLE
fix header bullshit 

### DIFF
--- a/resources/skins.tgui.styles/skinning/elements.less
+++ b/resources/skins.tgui.styles/skinning/elements.less
@@ -31,6 +31,7 @@ h3,
 h4,
 h5,
 h6 {
+  display: flow-root;
   position: relative;
   margin: 0;
   margin-top: 1em;


### PR DESCRIPTION
Добавил заголовкам (h1, h2, h3 ...) хуйню, что бы они не перекрывали шаблоны, картинки (обычно они находятся СПРАВА, или возможно страничка такая ВЖУХ и они стали СНИЗУ где есть заголовок) и на них можно было спокойно навестись